### PR TITLE
Enables the gem for sidekiq 4.x and adds one more stat

### DIFF
--- a/bin/riemann-sidekiq
+++ b/bin/riemann-sidekiq
@@ -30,7 +30,7 @@ class Riemann::Tools::Sidekiq
   def tick
     stats = ::Sidekiq::Stats.new
     begin
-      %w(processed failed enqueued scheduled_size retry_size dead_size).each do |m|
+      %w(processed failed workers_size enqueued scheduled_size retry_size dead_size).each do |m|
         metric = stats.send(m)
 
         state = if m.eql?("enqueued") && metric >= @enqueued_critical

--- a/riemann-sidekiq.gemspec
+++ b/riemann-sidekiq.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "riemann-tools", "~> 0.2.6"
   spec.add_runtime_dependency 'redis', '~> 3.2'
-  spec.add_runtime_dependency 'sidekiq', '~> 3.3'
+  spec.add_runtime_dependency 'sidekiq', '>= 3.3'
   spec.add_development_dependency "bundler", "~> 1.6"
 end


### PR DESCRIPTION
Hey,

thanks for the utility, it's really useful! I wanted to use it with sidekiq 4.0.2, so I changed to requirements - it works fine!

Also, I added the `workers_size` stat, the same one used to display the "Busy" figure in the official sidekiq admin panel.

Cheers!
