### PR TITLE
Report queue latency

### DIFF
--- a/bin/riemann-sidekiq
+++ b/bin/riemann-sidekiq
@@ -53,6 +53,10 @@ class Riemann::Tools::Sidekiq
           service: "sidekiq queues #{name}",
           metric: metric
         )
+        report(
+          service: "sidekiq latency #{name}",
+          metric: ::Sidekiq::Queue.new(name).latency
+        )
       end
     rescue => e
       puts e


### PR DESCRIPTION
I find the latency a quite useful statistic. The [sidekiq wiki](https://github.com/mperham/sidekiq/wiki/API) defines it as:
> now - when the oldest job was enqueued